### PR TITLE
fix: 修复文中一处代码错误

### DIFF
--- a/docs/docs/getting_started/basics.md
+++ b/docs/docs/getting_started/basics.md
@@ -379,7 +379,7 @@ Series 与 DataFrame 的算数函数支持 `fill_value` 选项，即用指定值
 df2 = pd.DataFrame({
    ....:     'one': pd.Series(np.random.randn(3), index=['a', 'b', 'c']),
    ....:     'two': pd.Series(np.random.randn(4), index=['a', 'b', 'c', 'd']),
-   ....:     'three': pd.Series(np.random.randn(3), index=['a', 'b', 'c', 'd'])})
+   ....:     'three': pd.Series(np.random.randn(4), index=['a', 'b', 'c', 'd'])})
    ....:
 ```
 :::


### PR DESCRIPTION
在「缺失值与填充缺失值操作」部分 `Tip` 下，文中声明的代码在实际执行中会出现 `ValueError: Length of passed values is 3, index implies 4` 异常，应当将 `randn(3)` 改为 `randn(4)`